### PR TITLE
No blas

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "deps/OpenBLAS"]
-	path = deps/OpenBLAS
-	url = https://github.com/xianyi/OpenBLAS.git
-
 [submodule "deps/pybind11"]
 	path = deps/pybind11
 	url = https://github.com/pybind/pybind11.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,12 +9,6 @@ option(VECSIM_STATIC "Build as static library" OFF)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../deps)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/OpenBLAS)
-
-# openblas
-set(USE_THREAD 0)
-set(DYNAMIC_ARCH 1)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../deps/OpenBLAS OpenBLAS)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -fPIC")
 
@@ -31,8 +25,6 @@ add_library(VectorSimilarity ${VECSIM_LIBTYPE}
     VecSim/spaces/internal_product.cpp
     VecSim/spaces/L2.cpp
     VecSim/utils/vec_utils.cpp)
-
-target_link_libraries(VectorSimilarity openblas)
 
 if(NOT VECSIM_STATIC)
     set_target_properties(VectorSimilarity PROPERTIES PREFIX "")

--- a/src/VecSim/spaces/L2.cpp
+++ b/src/VecSim/spaces/L2.cpp
@@ -158,7 +158,6 @@ static float L2SqrSIMD4ExtResiduals(const void *pVect1v, const void *pVect2v, co
 }
 #endif
 
-
 L2Space::L2Space(size_t dim) {
     fstdistfunc_ = L2Sqr;
 #if defined(USE_SSE) || defined(USE_AVX)

--- a/src/VecSim/spaces/L2.cpp
+++ b/src/VecSim/spaces/L2.cpp
@@ -158,7 +158,6 @@ static float L2SqrSIMD4ExtResiduals(const void *pVect1v, const void *pVect2v, co
 }
 #endif
 
-using namespace hnswlib;
 
 L2Space::L2Space(size_t dim) {
     fstdistfunc_ = L2Sqr;

--- a/src/VecSim/spaces/L2.h
+++ b/src/VecSim/spaces/L2.h
@@ -2,7 +2,6 @@
 
 #include "space_interface.h"
 
-namespace hnswlib {
 class L2Space : public SpaceInterface<float> {
 
     DISTFUNC<float> fstdistfunc_;
@@ -17,4 +16,3 @@ class L2Space : public SpaceInterface<float> {
     DISTFUNC<float> get_dist_func() const override;
     void *get_data_dim() override;
 };
-} // namespace hnswlib

--- a/src/VecSim/spaces/internal_product.cpp
+++ b/src/VecSim/spaces/internal_product.cpp
@@ -232,7 +232,6 @@ static float InnerProductSIMD4ExtResiduals(const void *pVect1v, const void *pVec
 }
 #endif
 
-using namespace hnswlib;
 
 InnerProductSpace::InnerProductSpace(size_t dim) {
     fstdistfunc_ = InnerProduct;

--- a/src/VecSim/spaces/internal_product.cpp
+++ b/src/VecSim/spaces/internal_product.cpp
@@ -232,7 +232,6 @@ static float InnerProductSIMD4ExtResiduals(const void *pVect1v, const void *pVec
 }
 #endif
 
-
 InnerProductSpace::InnerProductSpace(size_t dim) {
     fstdistfunc_ = InnerProduct;
 #if defined(USE_AVX) || defined(USE_SSE)

--- a/src/VecSim/spaces/internal_product.h
+++ b/src/VecSim/spaces/internal_product.h
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include "space_interface.h"
 
-namespace hnswlib {
 class InnerProductSpace : public SpaceInterface<float> {
 
     DISTFUNC<float> fstdistfunc_;
@@ -18,4 +17,3 @@ class InnerProductSpace : public SpaceInterface<float> {
     DISTFUNC<float> get_dist_func() const;
     void *get_data_dim();
 };
-} // namespace hnswlib

--- a/src/VecSim/spaces/space_interface.h
+++ b/src/VecSim/spaces/space_interface.h
@@ -23,7 +23,6 @@
 #endif
 #endif
 
-namespace hnswlib {
 template <typename TYPE> using DISTFUNC = TYPE (*)(const void *, const void *, const void *);
 
 template <typename TYPE> class SpaceInterface {
@@ -36,4 +35,3 @@ template <typename TYPE> class SpaceInterface {
 
     virtual ~SpaceInterface() = default;
 };
-} // namespace hnswlib

--- a/src/VecSim/utils/vec_utils.cpp
+++ b/src/VecSim/utils/vec_utils.cpp
@@ -1,8 +1,15 @@
 #include "vec_utils.h"
-#include "OpenBLAS/cblas.h"
+#include "math.h"
 
-void float_vector_normalize(float *x, int dim) {
-    float norm = cblas_snrm2(dim, x, 1);
-    norm = norm == 0.0 ? 0 : 1.0f / norm;
-    cblas_sscal(dim, norm, x, 1);
+void float_vector_normalize(float *x, size_t dim) {
+    float sum = 0;
+    for (size_t i = 0; i < dim; i++) {
+        sum += x[i] * x[i];
+    }
+    float norm = sqrt(sum);
+    if (norm == 0)
+        return;
+    for (size_t i = 0; i < dim; i++) {
+        x[i] = x[i] / norm;
+    }
 }

--- a/src/VecSim/utils/vec_utils.h
+++ b/src/VecSim/utils/vec_utils.h
@@ -1,3 +1,4 @@
 #pragma once
+#include "stdlib.h"
 
-void float_vector_normalize(float *x, int dim);
+void float_vector_normalize(float *x, size_t dim);

--- a/tests/unit/test_bruteforce.cpp
+++ b/tests/unit/test_bruteforce.cpp
@@ -465,3 +465,32 @@ TEST_F(BruteForceTest, brute_force_search_empty_index) {
     VecSimQueryResult_Free(res);
     VecSimIndex_Free(index);
 }
+
+TEST_F(BruteForceTest, brute_force_test_RS_integration_test) {
+    VecSimParams params = {
+        bfParams : {initialCapacity : 4},
+        type : VecSimType_FLOAT32,
+        size : 2,
+        metric : VecSimMetric_L2,
+        algo : VecSimAlgo_BF
+    };
+    size_t n = 4;
+    size_t k = 4;
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    VecSimIndex_AddVector(index, "abcdefgh", 1);
+    VecSimIndex_AddVector(index, "abcdefgg", 2);
+    VecSimIndex_AddVector(index, "aacdefgh", 3);
+    VecSimIndex_AddVector(index, "abbdefgh", 4);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 4);
+
+    VecSimQueryResult *res = VecSimIndex_TopKQuery(index, "abcdefgh", k, NULL);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 4);
+    ASSERT_EQ(1, res[0].id);
+    ASSERT_EQ(3, res[1].id);
+    ASSERT_EQ(2, res[2].id);
+    ASSERT_EQ(4, res[3].id);
+
+    VecSimQueryResult_Free(res);
+    VecSimIndex_Free(index);
+}

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -487,3 +487,32 @@ TEST_F(HNSWLibTest, hnsw_search_empty_index) {
     VecSimQueryResult_Free(res);
     VecSimIndex_Free(index);
 }
+
+TEST_F(HNSWLibTest, hnsw_test_RS_integration_test) {
+    VecSimParams params = {
+        bfParams : {initialCapacity : 4},
+        type : VecSimType_FLOAT32,
+        size : 2,
+        metric : VecSimMetric_L2,
+        algo : VecSimAlgo_HNSWLIB
+    };
+    size_t n = 4;
+    size_t k = 4;
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    VecSimIndex_AddVector(index, "abcdefgh", 1);
+    VecSimIndex_AddVector(index, "abcdefgg", 2);
+    VecSimIndex_AddVector(index, "aacdefgh", 3);
+    VecSimIndex_AddVector(index, "abbdefgh", 4);
+    ASSERT_EQ(VecSimIndex_IndexSize(index), 4);
+
+    VecSimQueryResult *res = VecSimIndex_TopKQuery(index, "abcdefgh", k, NULL);
+    ASSERT_EQ(VecSimQueryResult_Len(res), 4);
+    ASSERT_EQ(1, res[0].id);
+    ASSERT_EQ(3, res[1].id);
+    ASSERT_EQ(2, res[2].id);
+    ASSERT_EQ(4, res[3].id);
+
+    VecSimQueryResult_Free(res);
+    VecSimIndex_Free(index);
+}


### PR DESCRIPTION
This PR:
1. Removes OpenBLAS
2. Brute force is now using L2 and IP spaces with the vectorized commands
3. Solves a bug where `inf` is the given score for vector comparison in the brute force lookup.