### PR TITLE
Delete enter point bug

### DIFF
--- a/src/VecSim/algorithms/hnsw/hnswlib.h
+++ b/src/VecSim/algorithms/hnsw/hnswlib.h
@@ -809,13 +809,26 @@ bool HierarchicalNSW<dist_t>::removePoint(const labeltype label) {
         linklistsizeint *top_level_list = get_linklist_at_level(element_internal_id, maxlevel_);
         unsigned short list_len = getListCount(top_level_list);
         while (list_len == 0) {
-            maxlevel_--;
-            if (maxlevel_ < 0) {
-                enterpoint_node_ = -1;
-                break;
+            size_t elements = cur_element_count;
+            tableint cur_id = 0;
+            while (elements > 0) {
+                if (available_ids.find(&cur_id) == available_ids.end()) {
+                    elements--;
+                    top_level_list = get_linklist_at_level(cur_id, maxlevel_);
+                    if ((list_len = getListCount(top_level_list)))
+                        break;
+                }
+                cur_id++;
             }
-            top_level_list = get_linklist_at_level(element_internal_id, maxlevel_);
-            list_len = getListCount(top_level_list);
+            if (list_len == 0) {
+                maxlevel_--;
+                if (maxlevel_ < 0) {
+                    enterpoint_node_ = -1;
+                    break;
+                }
+                top_level_list = get_linklist_at_level(element_internal_id, maxlevel_);
+                list_len = getListCount(top_level_list);
+            }
         }
         // set the (arbitrary) first neighbor as the entry point (if there is some element in the
         // index).

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -87,7 +87,7 @@ VecSimIndexInfo HNSWIndex::info() {
     info.hnswInfo.efRuntime = this->hnsw.getEf();
     info.hnswInfo.indexSize = this->hnsw.getIndexSize();
     info.hnswInfo.levels = this->hnsw.getMaxLevel();
-    info.hnswInfo.entry = this->hnsw.getEnterPointLabel();
+    info.hnswInfo.entrypoint = this->hnsw.getEntryPointLabel();
     info.memory = this->allocator->getAllocationSize();
     return info;
 }

--- a/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
+++ b/src/VecSim/algorithms/hnsw/hnswlib_c.cpp
@@ -87,6 +87,7 @@ VecSimIndexInfo HNSWIndex::info() {
     info.hnswInfo.efRuntime = this->hnsw.getEf();
     info.hnswInfo.indexSize = this->hnsw.getIndexSize();
     info.hnswInfo.levels = this->hnsw.getMaxLevel();
+    info.hnswInfo.entry = this->hnsw.getEnterPointLabel();
     info.memory = this->allocator->getAllocationSize();
     return info;
 }

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -76,6 +76,7 @@ typedef struct {
             size_t efConstruction; // EF parameter for HNSW graph accuracy/latency for indexing.
             size_t efRuntime;      // EF parameter for HNSW graph accuracy/latency for search.
             size_t levels;         // Number of graph levels.
+            size_t entry;          // Entry vector label.
         } hnswInfo;
         struct {
             size_t indexSize; // Current count of vectors.

--- a/src/VecSim/vec_sim_common.h
+++ b/src/VecSim/vec_sim_common.h
@@ -76,7 +76,7 @@ typedef struct {
             size_t efConstruction; // EF parameter for HNSW graph accuracy/latency for indexing.
             size_t efRuntime;      // EF parameter for HNSW graph accuracy/latency for search.
             size_t levels;         // Number of graph levels.
-            size_t entry;          // Entry vector label.
+            size_t entrypoint;     // Entrypoint vector label.
         } hnswInfo;
         struct {
             size_t indexSize; // Current count of vectors.

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -545,7 +545,7 @@ TEST_F(HNSWLibTest, hnsw_bad_params) {
     }
 }
 
-TEST_F(HNSWLibTest, hnsw_delete_enter_point) {
+TEST_F(HNSWLibTest, hnsw_delete_entry_point) {
     size_t n = 10000;
     size_t dim = 2;
     size_t M = 2;
@@ -569,7 +569,7 @@ TEST_F(HNSWLibTest, hnsw_delete_enter_point) {
     VecSimIndexInfo info = VecSimIndex_Info(index);
 
     while (info.hnswInfo.indexSize > 0) {
-        ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, info.hnswInfo.entry));
+        ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, info.hnswInfo.entrypoint));
         info = VecSimIndex_Info(index);
     }
     VecSimIndex_Free(index);

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -558,6 +558,7 @@ TEST_F(HNSWLibTest, hnsw_delete_enter_point) {
         .algo = VecSimAlgo_HNSWLIB};
 
     VecSimIndex *index = VecSimIndex_New(&params);
+    ASSERT_TRUE(index != NULL);
 
     int64_t vec[dim];
     for (int i = 0; i < dim; i++)

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -544,3 +544,27 @@ TEST_F(HNSWLibTest, hnsw_bad_params) {
         ASSERT_TRUE(index == NULL);
     }
 }
+
+TEST_F(HNSWLibTest, hnsw_delete_enter_point) {
+    size_t n = 10000;
+    size_t dim = 2;
+    size_t M = 2;
+
+    VecSimParams params = {
+        .hnswParams = {.initialCapacity = n, .M = M, .efConstruction = 0, .efRuntime = 0},
+        .type = VecSimType_FLOAT32,
+        .size = dim,
+        .metric = VecSimMetric_L2,
+        .algo = VecSimAlgo_HNSWLIB};
+
+    VecSimIndex *index = VecSimIndex_New(&params);
+
+    int64_t vec[dim];
+    for (int i = 0; i < dim; i++)
+        vec[i] = i;
+    for (size_t j = 0; j < n; j++)
+        VecSimIndex_AddVector(index, vec, j);
+
+    for (size_t j = 0; j < n; j++)
+        ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, j));
+}

--- a/tests/unit/test_hnswlib.cpp
+++ b/tests/unit/test_hnswlib.cpp
@@ -566,6 +566,11 @@ TEST_F(HNSWLibTest, hnsw_delete_enter_point) {
     for (size_t j = 0; j < n; j++)
         VecSimIndex_AddVector(index, vec, j);
 
-    for (size_t j = 0; j < n; j++)
-        ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, j));
+    VecSimIndexInfo info = VecSimIndex_Info(index);
+
+    while (info.hnswInfo.indexSize > 0) {
+        ASSERT_NO_THROW(VecSimIndex_DeleteVector(index, info.hnswInfo.entry));
+        info = VecSimIndex_Info(index);
+    }
+    VecSimIndex_Free(index);
 }


### PR DESCRIPTION
in the case when we delete the index entry point:
if we don't find a neighbor of the entry point to replace it,
we need to check if there is any other vector in the entry point top level,
and only then check the level below.